### PR TITLE
Assets: SettingsPage.cs - Force resize preset view on start

### DIFF
--- a/Assets/SettingsPage.cs
+++ b/Assets/SettingsPage.cs
@@ -221,6 +221,7 @@ public class SettingsPage : MonoBehaviour {
         p2Inputs.inputParent.SetActive(!commonTimeSettings.useSameTime);
         beepMinutes.text = commonTimeSettings.beepMins.ToString();
         beepSeconds.text = commonTimeSettings.beepSecs.ToString();
+        LayoutRebuilder.ForceRebuildLayoutImmediate(presetParent.GetComponent<RectTransform>());
     }
 
     private bool ParseCurrentSettings() {


### PR DESCRIPTION
This fixes saved presets overlapping with the "Use same time for both players" checkbox.